### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -27,7 +27,7 @@ ButtonsCommanderSwitch	KEYWORD1
 ButtonsCommanderSwitchOnePin	KEYWORD1
 ButtonsCommanderSwitchTwoPins	KEYWORD1
 
-CommandersEventHandlerFunction	KETWORD1
+CommandersEventHandlerFunction	KEYWORD1
 Event	KEYWORD1
 EventPin	KEYWORD1
 EventStack	KEYWORD1
@@ -43,7 +43,7 @@ GetLastEventType	KEYWORD2
 GetLastEventData	KEYWORD2
 SetLastEventType	KEYWORD2
 SetLastEventData	KEYWORD2
-GetLastConfigAddress	
+GetLastConfigAddress	KEYWORD2
 RaiseEvent	KEYWORD2
 
 AddEvent	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -20,8 +20,8 @@ ButtonsCommander	KEYWORD1
 ButtonsCommanderAnalogPushes	KEYWORD1
 ButtonsCommanderAnalogPushesItem	KEYWORD1
 ButtonsCommanderButton	KEYWORD1
-ButtonsCommanderEncoder KEYWORD1
-ButtonsCommanderPotentiometer KEYWORD1
+ButtonsCommanderEncoder	KEYWORD1
+ButtonsCommanderPotentiometer	KEYWORD1
 ButtonsCommanderPush	KEYWORD1
 ButtonsCommanderSwitch	KEYWORD1
 ButtonsCommanderSwitchOnePin	KEYWORD1
@@ -48,7 +48,7 @@ RaiseEvent	KEYWORD2
 
 AddEvent	KEYWORD2
 AddEvents	KEYWORD2
-GetLastSelectedButton KEYWORD2
+GetLastSelectedButton	KEYWORD2
 
 GetId	KEYWORD2
 GetPosition	KEYWORD2


### PR DESCRIPTION
- Correct invalid/missing keywords.txt KEYWORD_TOKENTYPE
- Use correct field separator